### PR TITLE
Enable google-compute-engine to create slaves without public IP.

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -507,6 +507,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 // Always use our own credentials and let creation fail
                 // if no keys are provided.
                 options.as(GoogleComputeEngineTemplateOptions.class).autoCreateKeyPair(false);
+                options.as(GoogleComputeEngineTemplateOptions.class).assignExternalIp(assignPublicIp);
             }
 
             if (assignPublicIp) {

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-assignPublicIp.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-assignPublicIp.html
@@ -1,3 +1,4 @@
 <div>
-    Assign a public IP address. Switch supported by openstack-nova and cloudstack providers only.
+    Assign a public IP address. Switch supported by openstack-nova, cloudstack and
+    google-compute-engine providers only.
 </div>

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -42,6 +42,11 @@ limitations under the License.
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.jclouds.provider</groupId>
+      <artifactId>google-compute-engine</artifactId>
+      <version>2.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allcompute</artifactId>
       <version>${jclouds.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@ limitations under the License.
         <artifactId>jenkins-core</artifactId>
         <version>${jenkins.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.jclouds</groupId>
+        <artifactId>jclouds-all</artifactId>
+        <version>2.1.0-SNAPSHOT</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>
@@ -196,6 +201,13 @@ limitations under the License.
     <repository>
       <id>repo.jenkins-ci.org</id>
       <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+    <repository>
+      <id>jclouds-snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
     </repository>
   </repositories>
   <pluginRepositories>


### PR DESCRIPTION
This requires a build of jclouds with JCLOUDS-1355 changes included:
- https://issues.apache.org/jira/browse/JCLOUDS-1355
- https://github.com/jclouds/jclouds/pull/1157